### PR TITLE
Fix error on product search page in Magento 2.4.6

### DIFF
--- a/Observer/ProductsSearched.php
+++ b/Observer/ProductsSearched.php
@@ -56,7 +56,7 @@ class ProductsSearched implements ObserverInterface
             }
             $this->_croModel->storeGaEvents($eventName, $eventData);
         } catch (\Exception $e) {
-            $this->_logger->error(null, $e->getMessage());
+            $this->_logger->error($e->getMessage());
         }
     }
 }


### PR DESCRIPTION
Hello ! 

An error appear on search result page in Magento 2.4.6. 
This is the error : `main.CRITICAL: TypeError: Monolog\Logger::error(): Argument #2 ($context) must be of type array, string given, called in /var/www/html/vendor/croapp/integration/Observer/ProductsSearched.php on line 59 and defined in /var/www/html/vendor/monolog/monolog/src/Monolog/Logger.php:648`

This MR solve this problem on Magento 2.4.6, i didn't test other version.

Available if needed.
